### PR TITLE
Build tab screens

### DIFF
--- a/frontend/js/body.js
+++ b/frontend/js/body.js
@@ -1,9 +1,11 @@
 import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
+import { phaseBlurbs } from './phaseBlurbs.js';
 
 export async function renderBody() {
   try {
     const lowEnergy = isLowEnergy();
     const data = await fetchDailyGuidance(lowEnergy);
+    const blurb = phaseBlurbs.body[data.phase];
 
     const moveSuggestions = data.suggestions.filter(
       s => s.category === 'move' && !todayPickedIds.includes(s.id));
@@ -16,7 +18,7 @@ export async function renderBody() {
         <h2 id="body-heading">Body</h2>
         <p>Day ${data.day} - ${data.phase}</p>
       </header>
-
+      <p class="phase-blurb">${blurb}</p>
       <section id="nourish-section">
         <h3 id=nourish-heading>Nourish</h3>
         ${nourishSuggestions.slice(0, 2).map(s => `

--- a/frontend/js/body.js
+++ b/frontend/js/body.js
@@ -1,8 +1,42 @@
-export function renderBody() {
-  const content = document.getElementById("content");
+import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
 
-  content.innerHTML = `
-    <h2>Body</h2>
-    <p>Your daily guidance goes here.</p>
-  `;
+export async function renderBody() {
+  try {
+    const lowEnergy = isLowEnergy();
+    const data = await fetchDailyGuidance(lowEnergy);
+
+    const moveSuggestions = data.suggestions.filter(
+      s => s.category === 'move' && !todayPickedIds.includes(s.id));
+    const nourishSuggestions = data.suggestions.filter(
+      s => s.category === 'nourish' && !todayPickedIds.includes(s.id));
+    
+    const content = document.getElementById("content");
+    content.innerHTML = `
+      <header id="body-header">
+        <h2 id="body-heading">Body</h2>
+        <p>Day ${data.day} - ${data.phase}</p>
+      </header>
+
+      <section id="nourish-section">
+        <h3 id=nourish-heading>Nourish</h3>
+        ${nourishSuggestions.slice(0, 2).map(s => `
+          <div class="suggestion">
+            <strong>${s.title}</strong>
+            <p>${s.description}</p>
+          </div>
+        `).join('')}
+      </section>
+
+      <section id="move-section">
+        <h3 id="move-heading">Move</h3>
+        ${moveSuggestions.slice(0, 2).map(s => `
+          <div class="suggestion">
+            <strong>${s.title}</strong>
+            <p>${s.description}</p>
+          </div>
+        `).join('')}            
+    `;
+  }catch (errorObj) {
+      console.error(errorObj);
+  }
 }

--- a/frontend/js/mind.js
+++ b/frontend/js/mind.js
@@ -1,8 +1,27 @@
-export function renderMind() {
-  const content = document.getElementById("content");
+import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
 
-  content.innerHTML = `
-    <h2>Mind</h2>
-    <p>Your daily guidance goes here.</p>
-  `;
+export async function renderMind() {
+  try {
+    const lowEnergy = isLowEnergy();
+    const data = await fetchDailyGuidance(lowEnergy);
+
+    const mindSuggestions = data.suggestions.filter(
+      s => s.category === 'mind' && !todayPickedIds.includes(s.id));
+
+    const content = document.getElementById("content");
+    content.innerHTML = `
+      <header id="mind-header">
+        <h1 id="mind-heading"> Mind </h1>
+        <p>Day ${data.day} - ${data.phase}</p>
+      </header>
+      ${mindSuggestions.slice(0, 2).map(s => `
+        <div class="suggestion">
+          <strong>${s.title}</strong>
+          <p>${s.description}</p>
+        </div>
+      `).join('')}      
+    `;
+  }catch (errorObj) {
+      console.error(errorObj);
+  }
 }

--- a/frontend/js/mind.js
+++ b/frontend/js/mind.js
@@ -1,9 +1,11 @@
 import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
+import { phaseBlurbs } from './phaseBlurbs.js';
 
 export async function renderMind() {
   try {
     const lowEnergy = isLowEnergy();
     const data = await fetchDailyGuidance(lowEnergy);
+    const blurb = phaseBlurbs.mind[data.phase];
 
     const mindSuggestions = data.suggestions.filter(
       s => s.category === 'mind' && !todayPickedIds.includes(s.id));
@@ -14,6 +16,7 @@ export async function renderMind() {
         <h2 id="mind-heading"> Mind </h2>
         <p>Day ${data.day} - ${data.phase}</p>
       </header>
+      <p class="phase-blurb">${blurb}</p>
       ${mindSuggestions.slice(0, 2).map(s => `
         <div class="suggestion">
           <strong>${s.title}</strong>

--- a/frontend/js/mind.js
+++ b/frontend/js/mind.js
@@ -11,7 +11,7 @@ export async function renderMind() {
     const content = document.getElementById("content");
     content.innerHTML = `
       <header id="mind-header">
-        <h1 id="mind-heading"> Mind </h1>
+        <h2 id="mind-heading"> Mind </h2>
         <p>Day ${data.day} - ${data.phase}</p>
       </header>
       ${mindSuggestions.slice(0, 2).map(s => `

--- a/frontend/js/phaseBlurbs.js
+++ b/frontend/js/phaseBlurbs.js
@@ -1,0 +1,20 @@
+export const phaseBlurbs = {
+  mind: {
+    menstrual: "Your brain is in recovery mode. Executive function and working memory tend to dip right now, so keep tasks small and expectations gentle. Stick to things that feel like quick wins — your brain will thank you.",
+    follicular: "Mental clarity is building as estrogen rises. This is a strong window for planning, organizing, and starting new projects. Your brain is more open to learning and processing new information right now.",
+    ovulatory: "Your brain is at its sharpest. Verbal fluency, confidence, and problem-solving peak here. This is the time to tackle complex decisions, have important conversations, or work through anything you have been avoiding.",
+    luteal: "Focus is narrowing and your brain may feel foggier than usual. This is not a failure — it is your biology shifting gears. Keep your task list short, lean on routines, and avoid overcommitting."
+  },
+  body: {
+    menstrual: "Your body is doing important internal work right now. Energy and inflammation levels can fluctuate, so prioritize comfort and gentle nourishment. Choose warming, nutrient-dense foods and movement that feels restorative rather than demanding.",
+    follicular: "Energy is steadily rising and your body responds well to challenge right now. This is a good window to try new recipes, increase movement intensity gradually, and build momentum. Your body can handle more — but ease into it.",
+    ovulatory: "You are at peak physical energy. Your body can handle higher intensity movement and more complex meals. Fuel well to match the output — this is the time to push a little harder and enjoy the strength your body has right now.",
+    luteal: "Your body is winding down and preparing for the next cycle. Cravings, bloating, and fatigue are common and normal. Keep movement gentle, meals easy and grounding, and resist the urge to power through at full speed."
+  },
+  rest: {
+    menstrual: "Rest is not optional right now — it is part of the process. Your body is actively recovering and your nervous system needs extra stillness. Lower the bar for productivity and give yourself real permission to slow down.",
+    follicular: "Energy is climbing but sustainable habits start with rest. Use this upswing to build a wind-down routine that sticks. Going hard now without recovery sets you up for a crash later in the cycle.",
+    ovulatory: "High energy can trick you into skipping rest entirely. Social plans and productivity feel great right now, but protect at least one evening for yourself. Your nervous system still needs a chance to come down.",
+    luteal: "Your nervous system is more sensitive right now. Overstimulation hits harder, sleep can feel disrupted, and emotional regulation takes more effort. This is the phase where boundaries and early wind-downs matter most."
+  }
+};

--- a/frontend/js/rest.js
+++ b/frontend/js/rest.js
@@ -1,8 +1,27 @@
-export function renderRest() {
-  const content = document.getElementById("content");
+import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
 
-  content.innerHTML = `
-    <h2>Rest</h2>
-    <p>Your daily guidance goes here.</p>
-  `;
+export async function renderRest() {
+  try {
+    const lowEnergy = isLowEnergy();
+    const data = await fetchDailyGuidance(lowEnergy);
+
+    const restSuggestions = data.suggestions.filter(
+      s => s.category === 'rest' && !todayPickedIds.includes(s.id));
+
+    const content = document.getElementById("content");
+    content.innerHTML = `
+      <header id="rest-header">
+        <h2 id="rest-heading"> Rest </h2>
+        <p>Day ${data.day} - ${data.phase}</p>
+      </header>
+      ${restSuggestions.slice(0, 2).map(s => `
+        <div class="suggestion">
+          <strong>${s.title}</strong>
+          <p>${s.description}</p>
+        </div>
+      `).join('')}      
+    `;
+  }catch (errorObj) {
+      console.error(errorObj);
+  }
 }

--- a/frontend/js/rest.js
+++ b/frontend/js/rest.js
@@ -1,10 +1,12 @@
 import { fetchDailyGuidance, isLowEnergy, todayPickedIds } from "./api.js";
+import { phaseBlurbs } from './phaseBlurbs.js';
 
 export async function renderRest() {
   try {
     const lowEnergy = isLowEnergy();
     const data = await fetchDailyGuidance(lowEnergy);
-
+    const blurb = phaseBlurbs.rest[data.phase];
+    
     const restSuggestions = data.suggestions.filter(
       s => s.category === 'rest' && !todayPickedIds.includes(s.id));
 
@@ -14,6 +16,7 @@ export async function renderRest() {
         <h2 id="rest-heading"> Rest </h2>
         <p>Day ${data.day} - ${data.phase}</p>
       </header>
+      <p class="phase-blurb">${blurb}</p>
       ${restSuggestions.slice(0, 2).map(s => `
         <div class="suggestion">
           <strong>${s.title}</strong>


### PR DESCRIPTION
## Why
Builds the remaining tab screens so users can explore expanded suggestions beyond the Today screen's daily snapshot.

## Changes
- Built Mind tab with filtered suggestions excluding Today's picks
- Built Body tab with Nourish and Move sections
- Built Rest tab with recovery suggestions
- Created shared phaseBlurbs.js with phase-aware descriptions for all tabs
- All tabs use todayPickedIds to prevent duplicate suggestions

Closes #36 
