### PR TITLE
Add register, login, and logout endpoints

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -10,7 +10,8 @@ const PORT = process.env.PORT || 3000;
 
 // ---------- Imports ----------
 const express = require("express");
-const session = require('express-session')
+const session = require("express-session")
+const bcrypt = require("bcrypt");
 const path = require("path");
 const { Pool } = require("pg");
 const { getDailyGuidance, getEffortLevels } = require("./utils/cycleUtils");
@@ -35,6 +36,7 @@ app.use(session({
   saveUninitialized: false,
   cookie: {
     httpOnly: true,
+    sameSite: "lax",
     secure: false,
     maxAge: 1000 * 60 * 60 * 24 * 7
   }
@@ -61,6 +63,47 @@ app.get("/db-test", async (req, res) => {
     res.status(500).json({ ok: false, error: err.message });
   }
 });
+
+app.post("/register", async(req, res) => {
+  const { email, password } = req.body;
+  const errors = [];
+  
+  if (!email || !password) errors.push("Email and password are required");
+  if (password.length < 8) errors.push("Password must be at least 8 characters");
+  if (errors.length > 0 ) return res.status(400).json({ errors });
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const checkEmailQuery = `
+    SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)
+    `;
+
+  try {
+    const result = await pool.query(checkEmailQuery, [normalizedEmail]);
+    const emailExists = result.rows[0].exists;
+
+    if(emailExists) {
+      return res.status(409).json({
+        error: "An account with that email already exists"
+      })
+    }
+
+    const hash = await bcrypt.hash(password, 10);
+    
+    const insertUserQuery = `
+      INSERT INTO users(email, password_hash)
+      VALUES ($1, $2)
+    `;
+    
+    await pool.query(insertUserQuery, [normalizedEmail, hash]);
+
+    res.status(201).json({
+      message: "Account registered"
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 
 /**
  * POST /cycle-profile — Saves user's cycle configuration.

--- a/backend/server.js
+++ b/backend/server.js
@@ -140,6 +140,18 @@ app.post("/login", async(req, res) => {
   }
 });
 
+app.post("/logout", (req, res) => {
+  req.session.destroy((err) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({error: "Something went wrong"});
+    }
+    res.clearCookie("connect.sid");
+    res.status(200).json({message: "Logged out"});
+  })
+});
+
+
 /**
  * POST /cycle-profile — Saves user's cycle configuration.
  * Uses RETURNING * to send inserted row back without a separate SELECT.

--- a/backend/server.js
+++ b/backend/server.js
@@ -81,11 +81,7 @@ app.post("/register", async(req, res) => {
     const result = await pool.query(checkEmailQuery, [normalizedEmail]);
     const emailExists = result.rows[0].exists;
 
-    if(emailExists) {
-      return res.status(409).json({
-        error: "An account with that email already exists"
-      })
-    }
+    if(emailExists) return res.status(409).json({ error: "An account with that email already exists"});
 
     const hash = await bcrypt.hash(password, 10);
     
@@ -97,13 +93,52 @@ app.post("/register", async(req, res) => {
     await pool.query(insertUserQuery, [normalizedEmail, hash]);
 
     res.status(201).json({
-      message: "Account registered"
+      message: "Account created successfully"
     });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    console.error(err);
+    res.status(500).json({ error: "Something went wrong" });
   }
 });
 
+app.post("/login", async(req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) return res.status(400).json({ error: "Email and password required" });
+
+  const normalizedEmail = email.trim().toLowerCase();
+  try {
+    const loginQuery = `
+      SELECT id, password_hash FROM users WHERE email = $1
+      `;
+    const result = await pool.query(loginQuery, [normalizedEmail]);
+    const user = result.rows[0];
+    
+    if (!user) return res.status(401).json({ error: "Invalid credentials" });
+    
+    const match = await bcrypt.compare(password, user.password_hash);
+    if (!match) return res.status(401).json({ error: "Invalid credentials" });
+    
+    req.session.regenerate((err) => {
+      if (err) {
+        console.error(err);
+        return res.status(500).json({ error: "Something went wrong" });
+      }
+      req.session.userId = user.id;
+      req.session.save((err) => {
+        if (err) {
+          console.error(err);
+          return res.status(500).json({ error: "Something went wrong" });
+        }
+        res.status(200).json({ message: "Logged in" });
+      });
+    });
+  
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Something went wrong" });
+  }
+});
 
 /**
  * POST /cycle-profile — Saves user's cycle configuration.


### PR DESCRIPTION
Implements the three auth endpoints needed for users to create accounts and manage sessions.

POST /register
- Validates email and password, collecting all errors
- Checks for duplicate email before insert
- Hashes password with bcrypt (10 salt rounds)
- Returns 201 on success, 400 for validation, 409 for duplicates

POST /login
- Looks up user by normalized email
- Verifies password with bcrypt.compare
- Returns generic 401 for unknown email or wrong password (prevents enumeration)
- Regenerates session and sets userId on success
- Returns 200 with session cookie on success

POST /logout
- Destroys the session with req.session.destroy()
- Clears the session cookie on the response
- Returns 200

Error handling
- Raw err.message no longer returned to clients
- Errors logged server-side with console.error
- Generic "Something went wrong" message returned with 500 status

Testing
All cases verified in Bruno: success cases, validation failures, auth failures, duplicate handling, session cookie set/cleared correctly.

Closes #53 