### PR TITLE
Add period tracker screen with full CRUD functionality

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -323,7 +323,7 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
 
 app.post("/cycle-logs", requireAuth, async (req, res) => {
   const userId = req.session.userId;
-  const { periodStartDate } = req.body;
+  const { periodStartDate, notes } = req.body;
 
   if (!periodStartDate) {
     return res.status(400).json({
@@ -376,14 +376,15 @@ app.post("/cycle-logs", requireAuth, async (req, res) => {
     }
 
     const insertCycleLogQuery = `
-      INSERT INTO cycle_logs (user_id, period_start_date)
-      VALUES ($1, $2)
-      RETURNING id, period_start_date
+      INSERT INTO cycle_logs (user_id, period_start_date, notes)
+      VALUES ($1, $2, $3)
+      RETURNING id, period_start_date, notes
     `;
 
     const insertResult = await pool.query(insertCycleLogQuery, [
       userId,
       periodStartDate,
+      notes || null
     ]);
 
     return res.status(201).json({

--- a/backend/server.js
+++ b/backend/server.js
@@ -521,7 +521,7 @@ app.delete("/cycle-logs/:id", requireAuth, async (req, res) => {
   try {
     const deleteCycleLogQuery = `
       DELETE from cycle_logs
-      WHERE user_id = $1 AND id =$2
+      WHERE user_id = $1 AND id = $2
       RETURNING *
     `;
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -247,6 +247,12 @@ body.mode-onboarding {
   font-size: 2 rem;
 }
 
+.today-btns {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .logout-btn {
   padding: 0.5rem 0.875rem;
   font: inherit;

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -204,7 +204,7 @@ export async function updateCycleLog({ id, newPeriodStartDate, newNotes }) {
   return response.json();
 }
 
-export async function deleteCycleLog({ id, newPeriodStartDate, newNotes }) {
+export async function deleteCycleLog(id) {
   const response = await authedFetch(`${API_BASE_URL}/cycle-logs/${id}`, {
     method: "DELETE",
   });

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -36,6 +36,28 @@ export async function getMe() {
   return response.json();
 }
 
+export function setLowEnergy(active) {
+  localStorage.setItem("lowEnergy", JSON.stringify({
+    active,
+    date: new Date().toISOString().slice(0, 10)
+  }));
+}
+
+export function isLowEnergy() {
+  const stored = localStorage.getItem("lowEnergy");
+  if (!stored) return false;
+
+  const { active, date } = JSON.parse(stored);
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (date !== today) {
+    localStorage.removeItem("lowEnergy");
+    return false;
+  }
+
+  return active;
+}
+
 export async function postLogin({ email, password }) {
   const response = await fetch(`${API_BASE_URL}/login`, {
     method: "POST",
@@ -134,24 +156,48 @@ export async function fetchDailyGuidance(lowEnergy = false) {
   return data;
 }
 
-export function setLowEnergy(active) {
-  localStorage.setItem("lowEnergy", JSON.stringify({
-    active,
-    date: new Date().toISOString().slice(0, 10)
-  }));
-}
-
-export function isLowEnergy() {
-  const stored = localStorage.getItem("lowEnergy");
-  if (!stored) return false;
-
-  const { active, date } = JSON.parse(stored);
-  const today = new Date().toISOString().slice(0, 10);
-
-  if (date !== today) {
-    localStorage.removeItem("lowEnergy");
-    return false;
+export async function fetchCycleLogs() {
+  const response = await authedFetch(`${API_BASE_URL}/cycle-logs`);
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to retrieve period logs.");
   }
 
-  return active;
+  const data = await response.json();
+
+  return data;
 }
+
+export async function postCycleLog(periodStartDate) {
+  const response = await authedFetch(`${API_BASE_URL}/cycle-logs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ periodStartDate }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to save new period.");
+  }
+
+  return response.json();
+}
+
+// export async function updateCycleLog({ id, newPeriodStartDate, newNotes }) {
+//   const response = await authedFetch(`${API_BASE_URL}/cycle-logs`, {
+//     method: "PATCH",
+//     headers: { "Content-Type": "application/json" },
+//     body: JSON.stringify({
+//       id,
+//       newPeriodStartDate, 
+//       newNotes
+//     }),
+//   });
+
+//    if (!response.ok) {
+//     const errorData = await response.json();
+//     throw new Error(errorData.error || "Failed to edit period entry.");
+//   }
+
+//   return response.json();
+// }

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -168,11 +168,14 @@ export async function fetchCycleLogs() {
   return data;
 }
 
-export async function postCycleLog(periodStartDate) {
+export async function postCycleLog(periodStartDate, notes) {
   const response = await authedFetch(`${API_BASE_URL}/cycle-logs`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ periodStartDate }),
+    body: JSON.stringify({ 
+      periodStartDate,
+      notes
+   }),
   });
 
   if (!response.ok) {
@@ -183,21 +186,33 @@ export async function postCycleLog(periodStartDate) {
   return response.json();
 }
 
-// export async function updateCycleLog({ id, newPeriodStartDate, newNotes }) {
-//   const response = await authedFetch(`${API_BASE_URL}/cycle-logs`, {
-//     method: "PATCH",
-//     headers: { "Content-Type": "application/json" },
-//     body: JSON.stringify({
-//       id,
-//       newPeriodStartDate, 
-//       newNotes
-//     }),
-//   });
+export async function updateCycleLog({ id, newPeriodStartDate, newNotes }) {
+  const response = await authedFetch(`${API_BASE_URL}/cycle-logs/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      newPeriodStartDate, 
+      newNotes
+    }),
+  });
 
-//    if (!response.ok) {
-//     const errorData = await response.json();
-//     throw new Error(errorData.error || "Failed to edit period entry.");
-//   }
+   if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to edit period entry.");
+  }
 
-//   return response.json();
-// }
+  return response.json();
+}
+
+export async function deleteCycleLog({ id, newPeriodStartDate, newNotes }) {
+  const response = await authedFetch(`${API_BASE_URL}/cycle-logs/${id}`, {
+    method: "DELETE",
+  });
+
+   if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to delete period entry.");
+  }
+
+  return response.json();
+}

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -168,7 +168,7 @@ export async function fetchCycleLogs() {
   return data;
 }
 
-export async function postCycleLog(periodStartDate, notes) {
+export async function postCycleLog({ periodStartDate, notes }) {
   const response = await authedFetch(`${API_BASE_URL}/cycle-logs`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,6 @@
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
-}
+// if ('serviceWorker' in navigator) {
+//   navigator.serviceWorker.register('/sw.js');
+// }
 import { renderLogin } from './screens/login.js';
 import { renderOnboarding } from './screens/onboarding.js';
 import { renderToday } from './screens/today.js';

--- a/frontend/js/screens/today.js
+++ b/frontend/js/screens/today.js
@@ -36,7 +36,10 @@ export async function renderToday(onComplete) {
         <p class="cycle-info">Day ${data.day} · ${data.phase}</p>
       </div>
 
+      <div class="today-btns">
       <button type="button" id="logout-btn" class="logout-btn">Log out</button>
+      <button id="tracker-btn" class="logout-btn">Track Period</button>
+      </div>
     </header>
 
     <section class="today-screen">

--- a/frontend/js/screens/today.js
+++ b/frontend/js/screens/today.js
@@ -1,4 +1,5 @@
 import { fetchDailyGuidance, isLowEnergy, setLowEnergy, todayPickedIds, postLogout } from "../api.js";
+import { renderTracker } from "./tracker.js";
 
 export async function renderToday(onComplete) {
   try {
@@ -100,4 +101,7 @@ export async function renderToday(onComplete) {
   }
 });
 
+document.querySelector("#tracker-btn").addEventListener("click", async () => {
+  await renderTracker(onComplete);
+});
 }

--- a/frontend/js/screens/today.js
+++ b/frontend/js/screens/today.js
@@ -94,7 +94,6 @@ export async function renderToday(onComplete) {
     await postLogout();
     if (onComplete) {
       onComplete();
-    } else {
     }
   } catch (err) {
     console.error("Logout failed:", err);

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -41,7 +41,7 @@ export async function renderTracker(onBack) {
 
   const form = document.getElementById("period-log-form");
   const errorDisplay = document.getElementById("tracker-error");
-  const logsList = document.getElementById("period-logs");
+  const logsContainer = document.getElementById("period-logs");
   const dateInput = document.getElementById("period-start-date");
   const notesInput = document.getElementById("notes");
   const submitButton = form.querySelector('button[type="submit"]');
@@ -50,15 +50,15 @@ export async function renderTracker(onBack) {
   let editingLogId = null; //null means add mode; some id means edit mode
   
   async function loadCycleLogs() {
-    logsList.innerHTML = "<p>Loading period logs...</p>";
+    logsContainer.innerHTML = "<p>Loading period logs...</p>";
 
     try {
       const data = await fetchCycleLogs();
       currentLogs = data.data;
 
-      renderCycleLogs(logsList, currentLogs);
+      renderCycleLogs(logsContainer, currentLogs);
     } catch (err) {
-      logsList.innerHTML = "<p>Could not load period logs.</p>";
+      logsContainer.innerHTML = "<p>Could not load period logs.</p>";
       console.error(err);
     }
   }
@@ -95,7 +95,7 @@ export async function renderTracker(onBack) {
     }
   });
 
-  logsList.addEventListener("click", async (event) => {
+  logsContainer.addEventListener("click", async (event) => {
     if (event.target.classList.contains("delete-log-btn")) {
       if (!confirm("Delete this period log?")) return;
 
@@ -113,10 +113,9 @@ export async function renderTracker(onBack) {
     
     if (event.target.classList.contains("edit-log-btn")) {
       const entry = event.target.closest(".period-entry");
-      const logId = entry.dataset.logId;
-      editingLogId = logId;
+      editingLogId = entry.dataset.logId;
       const logToEdit = currentLogs.find((log) => {
-        return String(log.id) === String(logId);
+        return String(log.id) === String(editingLogId);
       });
       dateInput.value = logToEdit.period_start_date.slice(0, 10);
       notesInput.value = logToEdit.notes || "";

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -67,24 +67,37 @@ export async function renderTracker(onBack) {
 
   form.addEventListener("submit", async (event) => {
     event.preventDefault();
-
     errorDisplay.textContent = "";
 
     const formData = new FormData(form);
     const periodStartDate = formData.get("periodStartDate");
     const notes = formData.get("notes");
-    console.log({ periodStartDate, notes });
-
-    try {
-      await postCycleLog({ periodStartDate, notes });
-
-      form.reset();
-
-      await loadCycleLogs();
-    } catch (err) {
-      errorDisplay.textContent = err.message;
-      console.error(err);
+    if (editingLogId) {
+      try {
+        await updateCycleLog({
+          id: editingLogId,
+          newPeriodStartDate: periodStartDate,
+          newNotes: notes
+        });
+        editingLogId = null;
+        form.reset();
+        submitButton.textContent = "Save Period";
+        await loadCycleLogs();
+      } catch (err) {
+        errorDisplay.textContent = err.message;
+        console.error(err);
+      }
+    } else {
+      try {
+        await postCycleLog({ periodStartDate, notes });
+        form.reset();
+        await loadCycleLogs();
+      } catch (err) {
+        errorDisplay.textContent = err.message;
+        console.error(err);
+      }
     }
+    
   });
 
   logsList.addEventListener("click", async (event) => {
@@ -97,12 +110,23 @@ export async function renderTracker(onBack) {
       await deleteCycleLog(logId);
       await loadCycleLogs();
     }
+    
+    if (event.target.classList.contains("edit-log-btn")) {
+      const entry = event.target.closest(".period-entry");
+      const logId = entry.dataset.logId;
+      editingLogId = logId;
+      const logToEdit = currentLogs.find((log) => {
+        return String(log.id) === String(logId);
+      });
+      dateInput.value = logToEdit.period_start_date.slice(0, 10);
+      notesInput.value = logToEdit.notes || "";
+      submitButton.textContent = "Update Period";
+      //await loadCycleLogs();
+    }
   });
 
   loadCycleLogs();
 }
-
-
 
 function renderCycleLogs(container, logs) {
   container.innerHTML = "";

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -1,4 +1,6 @@
-export async function renderTracker(onComplete) {
+import { fetchCycleLogs, postCycleLog, updateCycleLog, deleteCycleLog } from "../api.js";
+
+export async function renderTracker(onBack) {
   const content = document.getElementById("content");
   content.innerHTML = `
     <header>
@@ -31,13 +33,75 @@ export async function renderTracker(onComplete) {
     
     <section>
       <h2>Previous periods</h2>
-      <div id="period-logs-list">
-        <p>Loading period logs...</p>
-      </div>
+      <div id="period-logs"></div>
     </section>
   `;
 
+  const form = document.getElementById("period-log-form");
+  const errorDisplay = document.getElementById("tracker-error");
+  const logsList = document.getElementById("period-logs");
+
   document.getElementById("back-btn").addEventListener("click", () => {
-    onComplete();
+    onBack();
+  });
+
+  loadCycleLogs(logsList);
+}
+
+async function loadCycleLogs(logsList) {
+  logsList.innerHTML = "<p>Loading period logs...</p>";
+
+  try {
+    const data = await fetchCycleLogs();
+    const logs = data.data;
+
+    renderCycleLogs(logsList, logs);
+  } catch (err) {
+    logsList.innerHTML = "<p>Could not load period logs.</p>";
+    console.error(err);
+  }
+}
+
+function renderCycleLogs(container, logs) {
+  container.innerHTML = "";
+
+  if (!logs || logs.length === 0) {
+    container.innerHTML = "<p>No period logs yet.</p>";
+    return;
+  }
+
+  logs.forEach((log) => {
+    const entry = document.createElement("div");
+    entry.classList.add("period-entry");
+    entry.dataset.logId = log.id;
+
+    const dateHeading = document.createElement("h4");
+    dateHeading.textContent = formatDateOnly(log.period_start_date);
+
+    const notesText = document.createElement("p");
+    notesText.textContent = log.notes || "No notes";
+
+    const actions = document.createElement("div");
+    actions.classList.add("period-entry-actions");
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.textContent = "Edit";
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.textContent = "Delete";
+
+    actions.append(editButton, deleteButton);
+    entry.append(dateHeading, notesText, actions);
+    container.appendChild(entry);
   });
 }
+
+function formatDateOnly(dateValue) {
+  const dateString = dateValue.slice(0, 10);
+  const [year, month, day] = dateString.split("-");
+
+  return `${month}/${day}/${year}`;
+}
+

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -102,8 +102,13 @@ export async function renderTracker(onBack) {
       const entry = event.target.closest(".period-entry");
       const logId = entry.dataset.logId;
  
-      await deleteCycleLog(logId);
-      await loadCycleLogs();
+      try {
+        await deleteCycleLog(logId);
+        await loadCycleLogs();
+      } catch (err) {
+        alert("Could not delete this log. Please try again.");
+        console.error(err);
+      }
     }
     
     if (event.target.classList.contains("edit-log-btn")) {

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -40,7 +40,27 @@ export async function renderTracker(onBack) {
   const form = document.getElementById("period-log-form");
   const errorDisplay = document.getElementById("tracker-error");
   const logsList = document.getElementById("period-logs");
+  const dateInput = document.getElementById("period-start-date");
+  const notesInput = document.getElementById("notes");
+  const submitButton = form.querySelector('button[type="submit"]');
+
+  let currentLogs = []; //logs currently loaded from the backend
+  let editingLogId = null; //null means add mode; some id means edit mode
   
+  async function loadCycleLogs() {
+    logsList.innerHTML = "<p>Loading period logs...</p>";
+
+    try {
+      const data = await fetchCycleLogs();
+      currentLogs = data.data;
+
+      renderCycleLogs(logsList, currentLogs);
+    } catch (err) {
+      logsList.innerHTML = "<p>Could not load period logs.</p>";
+      console.error(err);
+    }
+  }
+
   document.getElementById("back-btn").addEventListener("click", () => {
     onBack();
   });
@@ -60,7 +80,7 @@ export async function renderTracker(onBack) {
 
       form.reset();
 
-      await loadCycleLogs(logsList);
+      await loadCycleLogs();
     } catch (err) {
       errorDisplay.textContent = err.message;
       console.error(err);
@@ -70,31 +90,19 @@ export async function renderTracker(onBack) {
   logsList.addEventListener("click", async (event) => {
     if (event.target.classList.contains("delete-log-btn")) {
       if (!confirm("Delete this period log?")) return;
-      
+
       const entry = event.target.closest(".period-entry");
       const logId = entry.dataset.logId;
  
       await deleteCycleLog(logId);
-      await loadCycleLogs(logsList);
+      await loadCycleLogs();
     }
   });
 
-  loadCycleLogs(logsList);
+  loadCycleLogs();
 }
 
-async function loadCycleLogs(logsList) {
-  logsList.innerHTML = "<p>Loading period logs...</p>";
 
-  try {
-    const data = await fetchCycleLogs();
-    const logs = data.data;
-
-    renderCycleLogs(logsList, logs);
-  } catch (err) {
-    logsList.innerHTML = "<p>Could not load period logs.</p>";
-    console.error(err);
-  }
-}
 
 function renderCycleLogs(container, logs) {
   container.innerHTML = "";

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -2,9 +2,39 @@ export async function renderTracker(onComplete) {
   const content = document.getElementById("content");
   content.innerHTML = `
     <header>
-      <button id="back-btn">Back</button>
       <h1>Period Tracker</h1>
+      <button type="button" id="back-btn">Back</button>
     </header>
+    
+    <form id="period-log-form">
+      <label for="period-start-date">Add period</label>
+      <input
+          type="date"
+          id="period-start-date"
+          name="periodStartDate"
+          required
+        />
+
+      <label for="notes"> Notes:</label>
+      <textarea 
+        id="notes" 
+        name="notes" 
+        placeholder="Optional" 
+        rows="5" 
+        cols="33"
+      ></textarea>
+      
+      <p id="tracker-error"></p>
+
+      <button type="submit">Save Period</button>
+    </form>
+    
+    <section>
+      <h2>Previous periods</h2>
+      <div id="period-logs-list">
+        <p>Loading period logs...</p>
+      </div>
+    </section>
   `;
 
   document.getElementById("back-btn").addEventListener("click", () => {

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -69,6 +69,8 @@ export async function renderTracker(onBack) {
 
   logsList.addEventListener("click", async (event) => {
     if (event.target.classList.contains("delete-log-btn")) {
+      if (!confirm("Delete this period log?")) return;
+      
       const entry = event.target.closest(".period-entry");
       const logId = entry.dataset.logId;
  

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -1,0 +1,13 @@
+export async function renderTracker(onComplete) {
+  const content = document.getElementById("content");
+  content.innerHTML = `
+    <header>
+      <button id="back-btn">Back</button>
+      <h1>Period Tracker</h1>
+    </header>
+  `;
+
+  document.getElementById("back-btn").addEventListener("click", () => {
+    onComplete();
+  });
+}

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -29,6 +29,8 @@ export async function renderTracker(onBack) {
       <p id="tracker-error"></p>
 
       <button type="submit">Save Period</button>
+      <button type="button" id="cancel-edit-btn" style="display:none;">Cancel</button>
+
     </form>
     
     <section>
@@ -114,7 +116,14 @@ export async function renderTracker(onBack) {
       dateInput.value = logToEdit.period_start_date.slice(0, 10);
       notesInput.value = logToEdit.notes || "";
       submitButton.textContent = "Update Period";
-      //await loadCycleLogs();
+      document.getElementById("cancel-edit-btn").style.display = "inline";
+
+      document.getElementById("cancel-edit-btn").addEventListener("click", () => {
+        editingLogId = null;
+        form.reset();
+        submitButton.textContent = "Save Period";
+        document.getElementById("cancel-edit-btn").style.display = "none";
+      });
     }
   });
 

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -72,32 +72,25 @@ export async function renderTracker(onBack) {
     const formData = new FormData(form);
     const periodStartDate = formData.get("periodStartDate");
     const notes = formData.get("notes");
-    if (editingLogId) {
-      try {
+
+    try {
+      if (editingLogId) {
         await updateCycleLog({
           id: editingLogId,
           newPeriodStartDate: periodStartDate,
-          newNotes: notes
+          newNotes: notes,
         });
         editingLogId = null;
-        form.reset();
         submitButton.textContent = "Save Period";
-        await loadCycleLogs();
-      } catch (err) {
-        errorDisplay.textContent = err.message;
-        console.error(err);
-      }
-    } else {
-      try {
+      } else {
         await postCycleLog({ periodStartDate, notes });
-        form.reset();
-        await loadCycleLogs();
-      } catch (err) {
-        errorDisplay.textContent = err.message;
-        console.error(err);
       }
+      form.reset();
+      await loadCycleLogs();
+    } catch (err) {
+      errorDisplay.textContent = err.message;
+      console.error(err);
     }
-    
   });
 
   logsList.addEventListener("click", async (event) => {

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -40,10 +40,31 @@ export async function renderTracker(onBack) {
   const form = document.getElementById("period-log-form");
   const errorDisplay = document.getElementById("tracker-error");
   const logsList = document.getElementById("period-logs");
-
   document.getElementById("back-btn").addEventListener("click", () => {
     onBack();
   });
+
+  form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+
+  errorDisplay.textContent = "";
+
+  const formData = new FormData(form);
+  const periodStartDate = formData.get("periodStartDate");
+  const notes = formData.get("notes");
+  console.log({ periodStartDate, notes });
+
+  try {
+    await postCycleLog({ periodStartDate, notes });
+
+    form.reset();
+
+    await loadCycleLogs(logsList);
+  } catch (err) {
+    errorDisplay.textContent = err.message;
+    console.error(err);
+  }
+});
 
   loadCycleLogs(logsList);
 }

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -121,16 +121,16 @@ export async function renderTracker(onBack) {
       notesInput.value = selectedEntry.notes || "";
       submitButton.textContent = "Update Period";
       document.getElementById("cancel-edit-btn").style.display = "inline";
+    }
+  });
 
-      document.getElementById("cancel-edit-btn").addEventListener("click", () => {
+  document.getElementById("cancel-edit-btn").addEventListener("click", () => {
         activeEditId = null;
         form.reset();
         submitButton.textContent = "Save Period";
         document.getElementById("cancel-edit-btn").style.display = "none";
       });
-    }
-  });
-
+      
   loadEntries();
 }
 

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -8,7 +8,7 @@ export async function renderTracker(onBack) {
       <button type="button" id="back-btn">Back</button>
     </header>
     
-    <form id="period-log-form">
+    <form id="period-tracker-form">
       <label for="period-start-date">Add period</label>
       <input
           type="date"
@@ -34,31 +34,31 @@ export async function renderTracker(onBack) {
     </form>
     
     <section>
-      <h2>Previous periods</h2>
-      <div id="period-logs"></div>
+      <h2>Period History</h2>
+      <div id="period-log"></div>
     </section>
   `;
 
-  const form = document.getElementById("period-log-form");
+  const form = document.getElementById("period-tracker-form");
   const errorDisplay = document.getElementById("tracker-error");
-  const logsContainer = document.getElementById("period-logs");
+  const logContainer = document.getElementById("period-log");
   const dateInput = document.getElementById("period-start-date");
   const notesInput = document.getElementById("notes");
   const submitButton = form.querySelector('button[type="submit"]');
 
-  let currentLogs = []; //logs currently loaded from the backend
-  let editingLogId = null; //null means add mode; some id means edit mode
+  let logEntries = []; //logs currently loaded from the backend
+  let activeEditId = null; //null means add mode; some id means edit mode
   
-  async function loadCycleLogs() {
-    logsContainer.innerHTML = "<p>Loading period logs...</p>";
+  async function loadEntries() {
+    logContainer.innerHTML = "<p>Loading period logs...</p>";
 
     try {
       const data = await fetchCycleLogs();
-      currentLogs = data.data;
+      logEntries = data.data;
 
-      renderCycleLogs(logsContainer, currentLogs);
+      renderEntries(logContainer, logEntries);
     } catch (err) {
-      logsContainer.innerHTML = "<p>Could not load period logs.</p>";
+      logContainer.innerHTML = "<p>Could not load period log.</p>";
       console.error(err);
     }
   }
@@ -76,54 +76,54 @@ export async function renderTracker(onBack) {
     const notes = formData.get("notes");
 
     try {
-      if (editingLogId) {
+      if (activeEditId) {
         await updateCycleLog({
-          id: editingLogId,
+          id: activeEditId,
           newPeriodStartDate: periodStartDate,
           newNotes: notes,
         });
-        editingLogId = null;
+        activeEditId = null;
         submitButton.textContent = "Save Period";
       } else {
         await postCycleLog({ periodStartDate, notes });
       }
       form.reset();
-      await loadCycleLogs();
+      await loadEntries();
     } catch (err) {
       errorDisplay.textContent = err.message;
       console.error(err);
     }
   });
 
-  logsContainer.addEventListener("click", async (event) => {
-    if (event.target.classList.contains("delete-log-btn")) {
-      if (!confirm("Delete this period log?")) return;
+  logContainer.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("delete-entry-btn")) {
+      if (!confirm("Delete this period entry?")) return;
 
       const entry = event.target.closest(".period-entry");
-      const logId = entry.dataset.logId;
+      const entryId = entry.dataset.entryId;
  
       try {
-        await deleteCycleLog(logId);
-        await loadCycleLogs();
+        await deleteCycleLog(entryId);
+        await loadEntries();
       } catch (err) {
-        alert("Could not delete this log. Please try again.");
+        alert("Could not delete this entry. Please try again.");
         console.error(err);
       }
     }
     
-    if (event.target.classList.contains("edit-log-btn")) {
+    if (event.target.classList.contains("edit-entry-btn")) {
       const entry = event.target.closest(".period-entry");
-      editingLogId = entry.dataset.logId;
-      const logToEdit = currentLogs.find((log) => {
-        return String(log.id) === String(editingLogId);
+      activeEditId = entry.dataset.entryId;
+      const selectedEntry = logEntries.find((e) => {
+        return String(e.id) === String(activeEditId);
       });
-      dateInput.value = logToEdit.period_start_date.slice(0, 10);
-      notesInput.value = logToEdit.notes || "";
+      dateInput.value = selectedEntry.period_start_date.slice(0, 10);
+      notesInput.value = selectedEntry.notes || "";
       submitButton.textContent = "Update Period";
       document.getElementById("cancel-edit-btn").style.display = "inline";
 
       document.getElementById("cancel-edit-btn").addEventListener("click", () => {
-        editingLogId = null;
+        activeEditId = null;
         form.reset();
         submitButton.textContent = "Save Period";
         document.getElementById("cancel-edit-btn").style.display = "none";
@@ -131,44 +131,44 @@ export async function renderTracker(onBack) {
     }
   });
 
-  loadCycleLogs();
+  loadEntries();
 }
 
-function renderCycleLogs(container, logs) {
-  container.innerHTML = "";
+function renderEntries(logContainer, logEntries) {
+  logContainer.innerHTML = "";
 
-  if (!logs || logs.length === 0) {
-    container.innerHTML = "<p>No period logs yet.</p>";
+  if (!logEntries || logEntries.length === 0) {
+    logContainer.innerHTML = "<p>No period logged yet.</p>";
     return;
   }
 
-  logs.forEach((log) => {
-    const entry = document.createElement("div");
-    entry.classList.add("period-entry");
-    entry.dataset.logId = log.id;
+  logEntries.forEach((logEntry) => {
+    const entryDiv = document.createElement("div");
+    entryDiv.classList.add("period-entry");
+    entryDiv.dataset.entryId = logEntry.id;
 
     const dateHeading = document.createElement("h4");
-    dateHeading.textContent = formatDateOnly(log.period_start_date);
+    dateHeading.textContent = formatDateOnly(logEntry.period_start_date);
 
     const notesText = document.createElement("p");
-    notesText.textContent = log.notes || "No notes";
+    notesText.textContent = logEntry.notes || "No notes";
 
     const actions = document.createElement("div");
     actions.classList.add("period-entry-actions");
 
     const editButton = document.createElement("button");
-    editButton.classList.add("edit-log-btn");
+    editButton.classList.add("edit-entry-btn");
     editButton.type = "button";
     editButton.textContent = "Edit";
 
     const deleteButton = document.createElement("button");
-    deleteButton.classList.add("delete-log-btn");
+    deleteButton.classList.add("delete-entry-btn");
     deleteButton.type = "button";
     deleteButton.textContent = "Delete";
 
     actions.append(editButton, deleteButton);
-    entry.append(dateHeading, notesText, actions);
-    container.appendChild(entry);
+    entryDiv.append(dateHeading, notesText, actions);
+    logContainer.appendChild(entryDiv);
   });
 }
 

--- a/frontend/js/screens/tracker.js
+++ b/frontend/js/screens/tracker.js
@@ -40,31 +40,42 @@ export async function renderTracker(onBack) {
   const form = document.getElementById("period-log-form");
   const errorDisplay = document.getElementById("tracker-error");
   const logsList = document.getElementById("period-logs");
+  
   document.getElementById("back-btn").addEventListener("click", () => {
     onBack();
   });
 
   form.addEventListener("submit", async (event) => {
-  event.preventDefault();
+    event.preventDefault();
 
-  errorDisplay.textContent = "";
+    errorDisplay.textContent = "";
 
-  const formData = new FormData(form);
-  const periodStartDate = formData.get("periodStartDate");
-  const notes = formData.get("notes");
-  console.log({ periodStartDate, notes });
+    const formData = new FormData(form);
+    const periodStartDate = formData.get("periodStartDate");
+    const notes = formData.get("notes");
+    console.log({ periodStartDate, notes });
 
-  try {
-    await postCycleLog({ periodStartDate, notes });
+    try {
+      await postCycleLog({ periodStartDate, notes });
 
-    form.reset();
+      form.reset();
 
-    await loadCycleLogs(logsList);
-  } catch (err) {
-    errorDisplay.textContent = err.message;
-    console.error(err);
-  }
-});
+      await loadCycleLogs(logsList);
+    } catch (err) {
+      errorDisplay.textContent = err.message;
+      console.error(err);
+    }
+  });
+
+  logsList.addEventListener("click", async (event) => {
+    if (event.target.classList.contains("delete-log-btn")) {
+      const entry = event.target.closest(".period-entry");
+      const logId = entry.dataset.logId;
+ 
+      await deleteCycleLog(logId);
+      await loadCycleLogs(logsList);
+    }
+  });
 
   loadCycleLogs(logsList);
 }
@@ -106,10 +117,12 @@ function renderCycleLogs(container, logs) {
     actions.classList.add("period-entry-actions");
 
     const editButton = document.createElement("button");
+    editButton.classList.add("edit-log-btn");
     editButton.type = "button";
     editButton.textContent = "Edit";
 
     const deleteButton = document.createElement("button");
+    deleteButton.classList.add("delete-log-btn");
     deleteButton.type = "button";
     deleteButton.textContent = "Delete";
 


### PR DESCRIPTION
- Add tracker button to Today header to navigate to the tracker screen
- Build tracker screen with a form for logging new period start dates and optional notes
- Display period history as a list, rendered with DOM methods to prevent XSS from user-supplied notes
- Reuse the same form for both creating and editing entries, toggling between modes with a cancel button
- Wire edit and delete actions via event delegation on the log container
- Add delete confirmation dialog before removing entries
- Add API functions for all four cycle log endpoints (fetch, post, update, delete)
- Allow optional notes on POST /cycle-logs (backend and frontend)
- Route back to Today via onBack callback, avoiding circular imports

Closes #57 