### PR TITLE
Use latest period log for daily guidance

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -286,13 +286,25 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
     if (!profileResult.rows[0]) {
       return res.status(404).json({
         error: "No cycle profile found. Please enter your cycle information."
-      });
+      });  
     }
 
-    const cycleStartDate = profileResult.rows[0].cycle_start_date;
+    const logResult = await pool.query(
+      `SELECT period_start_date
+      FROM cycle_logs
+      WHERE user_id = $1
+      ORDER BY period_start_date DESC
+      LIMIT 1`,
+      [userId]
+    );
+
     const cycleLengthDays = profileResult.rows[0].cycle_length_days;
+    const profileCycleStartDate = profileResult.rows[0].cycle_start_date;
+    const latestLogDate = logResult.rows[0]?.period_start_date;
     
-    const dailyGuidance = getDailyGuidance(cycleStartDate, cycleLengthDays);
+    const activeCycleStartDate = latestLogDate || profileCycleStartDate;
+
+    const dailyGuidance = getDailyGuidance(activeCycleStartDate, cycleLengthDays);
     const phase = dailyGuidance.phase;
     const mode = dailyGuidance.mode;
     
@@ -325,6 +337,8 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
       phase: dailyGuidance.phase,
       mode: dailyGuidance.mode,
       cycle_profile: profileResult.rows[0],
+      cycle_start_date: activeCycleStartDate,
+      cycle_start_source: latestLogDate ? "period_log" : "profile",
       suggestions: suggestionsResult.rows,
     }); 
   } catch (err) {

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -6,6 +6,12 @@ let cacheDate = null;
 let onUnauthorized = null;
 export let todayPickedIds = [];
 
+export function clearDailyGuidanceCache() {
+  cachedGuidance = null;
+  cachedLowEnergyGuidance = null;
+  cacheDate = null;
+}
+
 export function setOnUnauthorized(callback) {
   onUnauthorized = callback;
 }
@@ -183,6 +189,7 @@ export async function postCycleLog({ periodStartDate, notes }) {
     throw new Error(errorData.error || "Failed to save new period.");
   }
 
+  clearDailyGuidanceCache();
   return response.json();
 }
 
@@ -201,6 +208,7 @@ export async function updateCycleLog({ id, newPeriodStartDate, newNotes }) {
     throw new Error(errorData.error || "Failed to edit period entry.");
   }
 
+  clearDailyGuidanceCache();
   return response.json();
 }
 
@@ -214,5 +222,6 @@ export async function deleteCycleLog(id) {
     throw new Error(errorData.error || "Failed to delete period entry.");
   }
 
+  clearDailyGuidanceCache();
   return response.json();
 }


### PR DESCRIPTION
## Summary

Updated daily guidance to use the latest logged period start date as the active cycle start date, with the profile cycle start date as a fallback when no logs exist.

Also cleared cached daily guidance after period logs are added, edited, or deleted so Today reflects updated tracker data.

## Testing

Confirmed Today updates after adding, editing, and deleting period logs.