### PR TITLE
Feature/cycle length insight

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -331,6 +331,10 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
       ORDER BY md5($3 || $4 || id::text)
       `,
     [allowedEffortLevels, phase, todayKey, userId]);
+    
+const cycleLengthInsight = {
+  available: false,
+};
 
     res.json({
       day: dailyGuidance.day,
@@ -339,6 +343,7 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
       cycle_profile: profileResult.rows[0],
       cycle_start_date: activeCycleStartDate,
       cycle_start_source: latestLogDate ? "period_log" : "profile",
+      cycle_length_insight: cycleLengthInsight,
       suggestions: suggestionsResult.rows,
     }); 
   } catch (err) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -298,11 +298,56 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
       [userId]
     );
 
+    const cycleLogsResult = await pool.query(
+      `
+      SELECT period_start_date
+      FROM cycle_logs
+      WHERE user_id = $1
+      ORDER BY period_start_date ASC
+      `,
+      [userId]
+    );
+    
     const cycleLengthDays = profileResult.rows[0].cycle_length_days;
     const profileCycleStartDate = profileResult.rows[0].cycle_start_date;
     const latestLogDate = logResult.rows[0]?.period_start_date;
-    
     const activeCycleStartDate = latestLogDate || profileCycleStartDate;
+    const periodStartDates = cycleLogsResult.rows.map((row) => {
+      return row.period_start_date;
+    });
+
+    let cycleLengthInsight = {
+      available: false,
+    };
+
+    if (periodStartDates.length >= 3) {
+      const gaps = [];
+
+      for (let i = 1; i < periodStartDates.length; i++) {
+        const previousDate = new Date(periodStartDates[i - 1]);
+        const currentDate = new Date(periodStartDates[i]);
+
+        const diffMs = currentDate - previousDate;
+        const diffDays = diffMs / (1000 * 60 * 60 * 24);
+
+        gaps.push(diffDays);
+      }
+      let sum = 0;
+
+      for (const gap of gaps) {
+        sum += gap;
+      }
+
+      const averageCycleLength = Math.round(sum / gaps.length);
+
+      cycleLengthInsight = {
+        available: true,
+        averageCycleLength,
+        loggedStartCount: periodStartDates.length,
+        gapCount: gaps.length,
+        storedCycleLength: cycleLengthDays,
+      };
+    }
 
     const dailyGuidance = getDailyGuidance(activeCycleStartDate, cycleLengthDays);
     const phase = dailyGuidance.phase;
@@ -332,10 +377,6 @@ app.get("/daily-guidance", requireAuth, async (req, res) => {
       `,
     [allowedEffortLevels, phase, todayKey, userId]);
     
-const cycleLengthInsight = {
-  available: false,
-};
-
     res.json({
       day: dailyGuidance.day,
       phase: dailyGuidance.phase,

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -97,10 +97,11 @@ body {
 }
 
 .energy-toggle {
-  background: var(--bg-surface);
+  background:rgba(255, 255, 255, 0.15);
   border-radius: 12px;
   padding: 1rem;
   margin-bottom: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
   width: fit-content;
   margin-left: auto;
   margin-right: auto;
@@ -604,6 +605,16 @@ body.mode-tracker {
   border: 1px solid #c45c5c;
   border-radius: 6px;
   cursor: pointer;
+}
+
+.cycle-insight {
+  font-size: 0.75rem;
+  margin: 8px 0 0 0;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(10px);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 @media (min-width: 768px) {

--- a/frontend/js/screens/today.js
+++ b/frontend/js/screens/today.js
@@ -35,6 +35,9 @@ export async function renderToday(onComplete) {
           ${data.mode}
         </h1>
         <p class="cycle-info">Day ${data.day} · ${data.phase}</p>
+        ${data.cycle_length_insight.available 
+          ? `<p class="cycle-insight">Current average cycle: <strong>${data.cycle_length_insight.averageCycleLength}</strong> days <br> Based on: <strong>${data.cycle_length_insight.loggedStartCount}</strong> entries</p>` 
+          : ''}
       </div>
 
       <div class="today-btns">


### PR DESCRIPTION
## Summary

Adds an informational cycle length insight based on logged period history. When enough period logs exist, Today shows the user’s current average logged cycle length.
This does not update the profile or change mode/phase calculations.

## Testing

- Confirmed banner appears with 3+ logged period starts
- Confirmed banner is hidden with fewer than 3 logged starts
- Confirmed Today guidance still works normally